### PR TITLE
Potential fix for code scanning alert no. 5: Overly permissive regular expression range

### DIFF
--- a/assets/plugins/plugins.js
+++ b/assets/plugins/plugins.js
@@ -3417,7 +3417,7 @@
 	}
 	var j = 'undefined' != typeof window,
 		k = Math.round(j ? window.devicePixelRatio || 1 : 1),
-		l = /(\.[A-z]{3,4}\/?(\?.*)?)$/,
+		l = /(\.[A-Za-z]{3,4}\/?(\?.*)?)$/,
 		m = /url\(('|")?([^)'"]+)('|")?\)/i,
 		n = '[data-rjs]',
 		o = 'data-rjs-processed';


### PR DESCRIPTION
Potential fix for [https://github.com/Mani19492/Singamsetti-Poorna-Mani-Teja---Cybersecurity-Portfolio-2026/security/code-scanning/5](https://github.com/Mani19492/Singamsetti-Poorna-Mani-Teja---Cybersecurity-Portfolio-2026/security/code-scanning/5)

To fix the issue, the overly permissive range `[A-z]` should be replaced with `[A-Za-z]`. This ensures that the regular expression matches only uppercase and lowercase alphabetic characters, excluding unintended characters like `[`, `\`, `]`, `^`, `_`, and `` ` ``. The change should be made on line 3420 in the file `assets/plugins/plugins.js`.

No additional imports, methods, or definitions are required to implement this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
